### PR TITLE
Fix to avoid generated images to be automatically reloaded

### DIFF
--- a/reload.py
+++ b/reload.py
@@ -133,8 +133,8 @@ def get_files_moddate(obj_type):
     
     for obj in getattr(bpy.data, obj_type):
 
-        # Avoid builtin
-        if obj.filepath in ["<builtin>", ""]:
+        # Avoid builtin and generated images
+        if obj.filepath in ["<builtin>", ""] or (hasattr(obj, 'source') and obj.source == 'GENERATED'):
             continue
         
         path = bpy.path.abspath(obj.filepath)

--- a/reload.py
+++ b/reload.py
@@ -133,8 +133,12 @@ def get_files_moddate(obj_type):
     
     for obj in getattr(bpy.data, obj_type):
 
-        # Avoid builtin and generated images
-        if obj.filepath in ["<builtin>", ""] or (hasattr(obj, 'source') and obj.source == 'GENERATED'):
+        # Avoid builtin
+        if obj.filepath in ["<builtin>", ""]:
+            continue
+
+        # Handle generated unsaved object like baked ucupaint images
+        if (hasattr(obj, 'source') and obj.source == 'GENERATED') :
             continue
         
         path = bpy.path.abspath(obj.filepath)


### PR DESCRIPTION
Hello, I'm the developer of Ucupaint, a layer manager addon for Blender (https://github.com/ucupumar/ucupaint). I have a PR to fix an issue if Auto Reload and Ucupaint are used together.

Some of the Ucupaint users reported that the bake result from Ucupaint can sometimes automatically turn to a flat color when Auto reload is turned ON. This is because Ucupaint bake result uses 'Generated' source while also filling the filepath property at certain cases, so auto reload mistakenly recognizes the image as an external image.

This is the demo video for the issue before patch, and the fixed behavior if the PR is merged.

https://github.com/user-attachments/assets/e9109991-0b08-46bb-a8f1-e13cc645d168

Blend file for testing: [autoreload_bug.zip](https://github.com/user-attachments/files/19793040/autoreload_bug.zip)